### PR TITLE
Add window scale letterbox for non-16:9/ultrawide monitors

### DIFF
--- a/PyTaiko.py
+++ b/PyTaiko.py
@@ -195,7 +195,16 @@ def main():
             ray.toggle_borderless_windowed()
             logger.info("Toggled borderless windowed mode")
 
-        scale = min(ray.get_screen_width() / screen_width, ray.get_screen_height() / screen_height)
+        curr_screen_width = ray.get_screen_width()
+        curr_screen_height = ray.get_screen_height()
+
+        if curr_screen_width == 0 or curr_screen_height == 0:
+            dest_rect = ray.Rectangle(0, 0, screen_width, screen_height)
+        else:    
+            scale = min(curr_screen_width / screen_width, curr_screen_height / screen_height)
+            dest_rect = ray.Rectangle((curr_screen_width - (screen_width * scale)) * 0.5,
+                (curr_screen_height - (screen_height * scale)) * 0.5,
+                screen_width * scale, screen_height * scale)
 
         ray.begin_texture_mode(target)
         ray.begin_blend_mode(ray.BlendMode.BLEND_CUSTOM_SEPARATE)
@@ -221,9 +230,7 @@ def main():
         ray.draw_texture_pro(
              target.texture,
              ray.Rectangle(0, 0, target.texture.width, -target.texture.height),
-             ray.Rectangle((ray.get_screen_width() - (screen_width * scale)) * 0.5,
-                (ray.get_screen_height() - (screen_height * scale)) * 0.5,
-                screen_width * scale, screen_height * scale),
+             dest_rect,
              ray.Vector2(0,0),
              0,
              ray.WHITE


### PR DESCRIPTION
Adds black pillarboxing to ultrawide monitors so the game isn't stretched in fullscreen, or letterboxing if the monitor's aspect ratio is taller than 16:9. Code adapted from the [raylib example](https://github.com/raysan5/raylib/blob/master/examples/core/core_window_letterbox.c#L95).