### PR TITLE
Add recurse_symlinks parameter to rglob to get tjas in symlinked folders

### DIFF
--- a/libs/song_hash.py
+++ b/libs/song_hash.py
@@ -80,7 +80,8 @@ def build_song_hashes(output_dir=Path("cache")):
     all_tja_files: list[Path] = []
     for root_dir in tja_paths:
         root_path = Path(root_dir)
-        all_tja_files.extend(root_path.rglob("*.tja"))
+        found_tja_files = root_path.rglob("*.tja", recurse_symlinks=True)
+        all_tja_files.extend(found_tja_files)
 
     global_data.total_songs = len(all_tja_files)
     files_to_process = []


### PR DESCRIPTION
Adds `recurse_symlinks=True` parameter to rglob to find .tja files in symlinked directories. Otherwise, the songs aren't added to the cache and folders in song select don't open despite song counts showing.

My genre folders are symlinks inside the base Songs folder like:
```
PyTaiko/Songs/
├── 01 Pop -> /home/somepin/tjas/01 Pop
├── 02 Anime -> /home/somepin/tjas/02 Anime
...
├── 11 Dan Dojo
├── 12 Downloaded
├── 13 Recommended
├── 14 Favorites
├── 15 Recently Played
├── 16 Difficulty Sort
└── 17 New
```

I fixed this before updating and seeing the readme section on adding paths through the config file, so this just enables another option.