### PR TITLE
Exclude dans from Recommended folder

### DIFF
--- a/libs/file_navigator.py
+++ b/libs/file_navigator.py
@@ -1233,7 +1233,7 @@ class FileNavigator:
                             sibling_key = str(sibling_path)
                             if sibling_key in self.directory_contents:
                                 for item in self.directory_contents[sibling_key]:
-                                    if not isinstance(item, Directory) and hasattr(item, 'tja'):
+                                    if not isinstance(item, Directory) and isinstance(item, SongFile):
                                         temp_items.append(item)
                     content_items = random.sample(temp_items, min(10, len(temp_items)))
 


### PR DESCRIPTION
Experienced a crash from attempting to navigate over a dan that was randomly added to Recommended, this ensures that only tjas with the expected attributes for song select are added to the folder.